### PR TITLE
Fix for match of children with same key on same level

### DIFF
--- a/ArrayMatch.php
+++ b/ArrayMatch.php
@@ -1,12 +1,9 @@
 <?php
 
-namespace App\Core;
-
 /**
  * Class ArrayMatch
- * @package App\Core
  */
-abstract class ArrayMatch
+class ArrayMatch
 {
     /**
      * @param string $pattern
@@ -59,21 +56,23 @@ abstract class ArrayMatch
         $nextPart = next($parts);
 
         foreach ($data as $key => $value) {
+            $tempParts = $parts;
+
             $track = array_slice($track, 0, $level);
             $track[] = $key;
 
             if ($nextPart && is_array($value)) {
                 if ($currentPart === '*') {
                     if (array_key_exists($nextPart, $value)) {
-                        array_shift($parts);
+                        array_shift($tempParts);
                     } else {
-                        reset($parts);
+                        reset($tempParts);
                     }
 
-                    self::_match($parts, $value, $matches, $track, $level + 1);
+                    self::_match($tempParts, $value, $matches, $track, $level + 1);
                 } elseif ($currentPart === $key) {
-                    array_shift($parts);
-                    self::_match($parts, $value, $matches, $track, $level + 1);
+                    array_shift($tempParts);
+                    self::_match($tempParts, $value, $matches, $track, $level + 1);
                 }
             } elseif (!$nextPart && ($key === $currentPart || $currentPart === '*')) {
                 $matches[] = ['track' => $track, 'value' => $value];

--- a/ArrayMatchTest.php
+++ b/ArrayMatchTest.php
@@ -1,14 +1,9 @@
 <?php
 
-namespace App\Tests\Unit\Core;
-
-use DateTime;
-use Exception;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Class ArrayMatchTest
- * @package App\Tests\Unit\Core
  */
 class ArrayMatchTest extends TestCase
 {
@@ -61,6 +56,7 @@ class ArrayMatchTest extends TestCase
                 '*.hello.*.world' => ['replaceWith' => 'replaced hello world', 'shouldMatch' => true],
                 '*.date' => ['replaceWith' => 'replaced date', 'shouldMatch' => true],
                 'foo.bar' => ['replaceWith' => 'shouldn\'t be replaced', 'shouldMatch' => false],
+                'blocks.*.page_link' => ['replaceWith' => 'replaced blocks', 'shouldMatch' => true],
             ],
             'array' => [
                 [false => [['date' => new DateTime('2021-01-01 13:00:00')]]],
@@ -92,7 +88,18 @@ class ArrayMatchTest extends TestCase
                         ],
                     ]
                 ],
-                'bar' => 456
+                'bar' => 456,
+                'blocks' => [
+                    [
+                        'page_link' => 1
+                    ],
+                    [
+                        'page_link' => 2
+                    ],
+                    [
+                        'page_link' => 3
+                    ]
+                ]
             ]
         ];
     }
@@ -142,7 +149,21 @@ class ArrayMatchTest extends TestCase
                         'value' => '3'
                     ],
                 ],
-                null
+                null,
+                [
+                    [
+                        'track' => ['blocks', 0, 'page_link'],
+                        'value' => 1
+                    ],
+                    [
+                        'track' => ['blocks', 1, 'page_link'],
+                        'value' => 2
+                    ],
+                    [
+                        'track' => ['blocks', 2, 'page_link'],
+                        'value' => 3
+                    ],
+                ]
             ],
             'array' => [
                 [false => [['date' => 'replaced date']]],
@@ -170,7 +191,18 @@ class ArrayMatchTest extends TestCase
                         'foo' => 'replaced foo'
                     ]
                 ],
-                'bar' => 456
+                'bar' => 456,
+                'blocks' => [
+                    [
+                        'page_link' => 'replaced blocks'
+                    ],
+                    [
+                        'page_link' => 'replaced blocks'
+                    ],
+                    [
+                        'page_link' => 'replaced blocks'
+                    ]
+                ]
             ]
         ];
     }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Search a recursive array with string patterns e.g. `*.hello.*.world` (also supports wildcard).
 
 Example:
-```
+```php
 $array = [
     'foo' => [
         'bar' => 'value'


### PR DESCRIPTION
Match all children with the same key on the same level instead of only the first result.