### PR TITLE
Replace "null" with array type

### DIFF
--- a/ArrayMatch.php
+++ b/ArrayMatch.php
@@ -9,11 +9,11 @@ class ArrayMatch
      * @param string $pattern
      * @param array $array
      * @param array|null $matches
-     * @return mixed|null
+     * @return bool
      */
     public static function match(string $pattern, array $array, array &$matches = null)
     {
-        $matches = null;
+        $matches = [];
         $parts = explode('.', $pattern);
 
         self::_match($parts, $array, $matches);


### PR DESCRIPTION
Replace "null" with array type to return an array as empty value when zero matches are found.